### PR TITLE
fix api design url

### DIFF
--- a/.github/workflows/markdown_link_checker.yml
+++ b/.github/workflows/markdown_link_checker.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@1.0.12
+      uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
       with:
         folder-path: 'text'
 

--- a/text/0004-code-standards.md
+++ b/text/0004-code-standards.md
@@ -54,7 +54,7 @@ Using an RFC process to manage code style and standards
 by the rust-lang team.
 
 As far as specific standards, Rust has
-[API design guidelines](https://rust-lang-nursery.github.io/api-guidelines/).
+[API design guidelines](https://rust-lang.github.io/api-guidelines/).
 
 ## Unresolved questions
 

--- a/text/code-standards/api-design.md
+++ b/text/code-standards/api-design.md
@@ -1,4 +1,4 @@
 # API Design
 
 Refer to the Rust API Design guidelines.
-<https://rust-lang-nursery.github.io/api-guidelines/>
+<https://rust-lang.github.io/api-guidelines/>


### PR DESCRIPTION
api design guidelines are no longer in the nursery