### PR TITLE
rust-compiler-version.md Update to Rust 2021

### DIFF
--- a/text/code-standards/rust-compiler-version.md
+++ b/text/code-standards/rust-compiler-version.md
@@ -1,3 +1,3 @@
 # Rust Compiler Versions
 
-RFC in progress [here](https://github.com/FuelLabs/rfcs/pull/6).
+Use Rust 2021 ( [related PR for discussion](https://github.com/FuelLabs/rfcs/pull/6) ).


### PR DESCRIPTION
PR 6 is closed wtih "N/A; 2021 is stable and the migration is transparent" , so updating documentation to use Rust 2021.

PR 6 : https://github.com/FuelLabs/rfcs/pull/6